### PR TITLE
fix: replace ascending sort+reverse with direct descending comparator in deprecated history migration

### DIFF
--- a/imixs-office-workflow-util/src/main/java/org/imixs/workflow/office/forms/ChronicleController.java
+++ b/imixs-office-workflow-util/src/main/java/org/imixs/workflow/office/forms/ChronicleController.java
@@ -138,24 +138,20 @@ public class ChronicleController implements Serializable {
 				&& workflowController.getWorkitem().hasItem("txtworkflowhistory")) {
 			// migrate deprecated field name
 			history = workflowController.getWorkitem().getItemValue("txtworkflowhistory");
-			// in old workitems, the workflow history may not be ordered chronological.
-			// We re-sort the order here
-			// Sort the list by date in descending order
+			// in old workitems, the workflow history may not be ordered chronologically.
+			// re-sort in descending order directly
 			Collections.sort(history, new Comparator<List<?>>() {
 				@Override
 				public int compare(List<?> entry1, List<?> entry2) {
 					Date date1 = (Date) entry1.get(0);
 					Date date2 = (Date) entry2.get(0);
-					// Compare in descending order
-					return date1.compareTo(date2);
+					return date2.compareTo(date1);
 				}
 			});
 		} else {
 			history = workflowController.getWorkitem().getItemValue(HistoryPlugin.ITEM_HISTORY_LOG);
 		}
 
-		// change order
-		Collections.reverse(history);
 		// do we have real history entries?
 		if (history.size() > 0 && history.get(0) instanceof List) {
 			for (List<?> entries : history) {


### PR DESCRIPTION
Hi,
small cleanup in `ChronicleController`:
the legacy history field (`txtworkflowhistory`) was previously sorted ascending and then flipped via `Collections.reverse()`. The comparator now sorts directly descending (`date2.compareTo(date1)`), removing the redundant `reverse()` call. Same semantics, cleaner code, one less iteration.