### PR TITLE
refactor: migrate IBAN/BIC validation to iban-commons

### DIFF
--- a/imixs-office-workflow-util/pom.xml
+++ b/imixs-office-workflow-util/pom.xml
@@ -63,11 +63,11 @@
 			<artifactId>imixs-adapters-poi</artifactId>
 		</dependency>
 
-		<!-- tiny java lib for iban/bic validation -->
+		<!-- tiny java lib for IBAN/BIC validation -->
 		<dependency>
-			<groupId>org.iban4j</groupId>
-			<artifactId>iban4j</artifactId>
-			<version>3.2.7-RELEASE</version>
+			<groupId>de.speedbanking</groupId>
+			<artifactId>iban-commons</artifactId>
+			<version>1.8.3</version>
 		</dependency>
 
 	</dependencies>

--- a/imixs-office-workflow-util/src/main/java/org/imixs/workflow/office/forms/BICValidator.java
+++ b/imixs-office-workflow-util/src/main/java/org/imixs/workflow/office/forms/BICValidator.java
@@ -1,9 +1,7 @@
 package org.imixs.workflow.office.forms;
 
-import org.iban4j.BicFormatException;
-import org.iban4j.BicUtil;
-import org.iban4j.InvalidCheckDigitException;
-import org.iban4j.UnsupportedCountryException;
+import de.speedbanking.bic.Bic;
+import de.speedbanking.bic.InvalidBicException;
 
 import jakarta.faces.application.FacesMessage;
 import jakarta.faces.component.UIComponent;
@@ -12,24 +10,27 @@ import jakarta.faces.validator.FacesValidator;
 import jakarta.faces.validator.Validator;
 import jakarta.faces.validator.ValidatorException;
 
+/**
+ * JSF validator for BIC (ISO 9362) inputs.
+ * <p>
+ * Delegates validation to {@link Bic#of(CharSequence)} from the
+ * <em>iban-commons</em> library (de.speedbanking). Both BIC-8
+ * ("MARKDEFF") and BIC-11 ("MARKDEFFXXX") formats are accepted.
+ * Whitespace is stripped before validation.
+ *
+ * @see <a href="https://github.com/SpeedBankingDe/iban-commons">iban-commons</a>
+ */
 @FacesValidator("imixsBICValidator")
 public class BICValidator implements Validator<String> {
 
     @Override
     public void validate(FacesContext context, UIComponent component, String value) throws ValidatorException {
-        // Fügen Sie hier Ihre Validierungslogik hinzu
         if (value != null && !value.isEmpty()) {
 
             try {
-                // strip spaces?
-                if (value.contains(" ")) {
-                    // yes...
-                    value = value.replaceAll("\\s+", "");
-                }
-                BicUtil.validate(value);
-            } catch (BicFormatException | InvalidCheckDigitException | UnsupportedCountryException e) {
-
-                throw new ValidatorException(new FacesMessage(e.getMessage()));
+                Bic.of(value.replaceAll("\\s+", ""));
+            } catch (InvalidBicException ex) {
+                throw new ValidatorException(new FacesMessage(ex.getMessage()), ex);
             }
 
         }

--- a/imixs-office-workflow-util/src/main/java/org/imixs/workflow/office/forms/IBANValidator.java
+++ b/imixs-office-workflow-util/src/main/java/org/imixs/workflow/office/forms/IBANValidator.java
@@ -1,10 +1,7 @@
 package org.imixs.workflow.office.forms;
 
-import org.iban4j.IbanFormat;
-import org.iban4j.IbanFormatException;
-import org.iban4j.IbanUtil;
-import org.iban4j.InvalidCheckDigitException;
-import org.iban4j.UnsupportedCountryException;
+import de.speedbanking.iban.Iban;
+import de.speedbanking.iban.InvalidIbanException;
 
 import jakarta.faces.application.FacesMessage;
 import jakarta.faces.component.UIComponent;
@@ -13,25 +10,27 @@ import jakarta.faces.validator.FacesValidator;
 import jakarta.faces.validator.Validator;
 import jakarta.faces.validator.ValidatorException;
 
+/**
+ * JSF validator for IBAN (ISO 13616) inputs.
+ * <p>
+ * Delegates validation to {@link Iban#of(CharSequence)} from the
+ * <em>iban-commons</em> library (de.speedbanking). The library automatically
+ * handles whitespace, so both formatted ("DE91 1000 0000 0123 4567 89") 
+ * and unformatted ("DE91100000000123456789") input is accepted.
+ *
+ * @see <a href="https://github.com/SpeedBankingDe/iban-commons">iban-commons</a>
+ */
 @FacesValidator("imixsIBANValidator")
 public class IBANValidator implements Validator<String> {
 
     @Override
     public void validate(FacesContext context, UIComponent component, String value) throws ValidatorException {
-        // Fügen Sie hier Ihre Validierungslogik hinzu
         if (value != null && !value.isEmpty()) {
 
             try {
-                if (value.contains(" ")) {
-                    // formated
-                    IbanUtil.validate(value, IbanFormat.Default);
-                } else {
-                    // normal
-                    IbanUtil.validate(value, IbanFormat.None);
-                }
-            } catch (IbanFormatException | InvalidCheckDigitException | UnsupportedCountryException e) {
-
-                throw new ValidatorException(new FacesMessage(e.getMessage()));
+                Iban.of(value);
+            } catch (InvalidIbanException ex) {
+                throw new ValidatorException(new FacesMessage(ex.getMessage()), ex);
             }
 
         }

--- a/imixs-office-workflow-util/src/test/java/org/imixs/workflow/office/forms/BICValidatorTest.java
+++ b/imixs-office-workflow-util/src/test/java/org/imixs/workflow/office/forms/BICValidatorTest.java
@@ -1,0 +1,97 @@
+package org.imixs.workflow.office.forms;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.validator.ValidatorException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for {@link BICValidator}.
+ * <p>
+ * {@code FacesContext} and {@code UIComponent} are mocked via Mockito since
+ * the validator does not interact with them beyond receiving the value.
+ */
+public class BICValidatorTest {
+
+    private BICValidator validator;
+    private FacesContext facesContext;
+    private UIComponent  component;
+
+    @BeforeEach
+    void setUp() {
+        validator = new BICValidator();
+        facesContext = mock(FacesContext.class);
+        component = mock(UIComponent.class);
+    }
+
+    @Test
+    void testValidBIC8_DeutscheBundesbank() {
+        assertDoesNotThrow(() ->
+            validator.validate(facesContext, component, "MARKDEFF"));
+    }
+
+    @Test
+    void testValidBIC8_Commerzbank() {
+        assertDoesNotThrow(() ->
+            validator.validate(facesContext, component, "COBADEFF"));
+    }
+
+    @Test
+    void testValidBIC11_withBranchCode() {
+        assertDoesNotThrow(() ->
+            validator.validate(facesContext, component, "PALSPS22XXX"));
+    }
+
+    @Test
+    void testValidBIC11_DeutscheBundesbank() {
+        assertDoesNotThrow(() ->
+            validator.validate(facesContext, component, "MARKDEFFXXX"));
+    }
+
+    @Test
+    void testValidBIC_withSpaces() {
+        assertDoesNotThrow(() ->
+            validator.validate(facesContext, component, "MARK DEFF"));
+    }
+
+    @Test
+    void testNullValue_noException() {
+        assertDoesNotThrow(() ->
+            validator.validate(facesContext, component, null));
+    }
+
+    @Test
+    void testEmptyValue_noException() {
+        assertDoesNotThrow(() ->
+            validator.validate(facesContext, component, ""));
+    }
+
+    @Test
+    void testInvalidBIC_tooShort() {
+        ValidatorException ex = assertThrows(ValidatorException.class, () ->
+            validator.validate(facesContext, component, "MARK"));
+        assertNotNull(ex.getFacesMessage());
+        assertEquals("BIC has incorrect length", ex.getFacesMessage().getSummary());
+    }
+
+    @Test
+    void testInvalidBIC_invalidCountryCode() {
+        ValidatorException ex = assertThrows(ValidatorException.class, () ->
+            validator.validate(facesContext, component, "MARK11FF"));
+        assertNotNull(ex.getFacesMessage());
+        assertEquals("BIC has invalid country code", ex.getFacesMessage().getSummary());
+    }
+
+    @Test
+    void testInvalidBIC_garbage() {
+        ValidatorException ex = assertThrows(ValidatorException.class, () ->
+            validator.validate(facesContext, component, "NOT-A-BIC"));
+        assertNotNull(ex.getFacesMessage());
+        assertEquals("BIC has incorrect length", ex.getFacesMessage().getSummary());
+    }
+
+}

--- a/imixs-office-workflow-util/src/test/java/org/imixs/workflow/office/forms/IBANValidatorTest.java
+++ b/imixs-office-workflow-util/src/test/java/org/imixs/workflow/office/forms/IBANValidatorTest.java
@@ -1,0 +1,115 @@
+package org.imixs.workflow.office.forms;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.validator.ValidatorException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for {@link IBANValidator}.
+ * <p>
+ * {@code FacesContext} and {@code UIComponent} are mocked via Mockito since
+ * the validator does not interact with them beyond receiving the value.
+ */
+public class IBANValidatorTest {
+
+    private IBANValidator validator;
+    private FacesContext  facesContext;
+    private UIComponent   component;
+
+    @BeforeEach
+    void setUp() {
+        validator = new IBANValidator();
+        facesContext = mock(FacesContext.class);
+        component = mock(UIComponent.class);
+    }
+
+    @Test
+    void testValidIBAN_DE_unformatted() {
+        assertDoesNotThrow(() ->
+            validator.validate(facesContext, component, "DE91100000000123456789"));
+    }
+
+    @Test
+    void testValidIBAN_GB_unformatted() {
+        assertDoesNotThrow(() ->
+            validator.validate(facesContext, component, "GB82WEST12345698765432"));
+    }
+
+    @Test
+    void testValidIBAN_CH_unformatted() {
+        assertDoesNotThrow(() ->
+            validator.validate(facesContext, component, "CH9300762011623852957"));
+    }
+
+    @Test
+    void testValidIBAN_DE_formatted() {
+        assertDoesNotThrow(() ->
+            validator.validate(facesContext, component, "DE91 1000 0000 0123 4567 89"));
+    }
+
+    @Test
+    void testValidIBAN_GB_formatted() {
+        assertDoesNotThrow(() ->
+            validator.validate(facesContext, component, "GB82 WEST 1234 5698 7654 32"));
+    }
+
+    // --- edge cases: null and empty must not throw ---
+
+    @Test
+    void testNullValue_noException() {
+        assertDoesNotThrow(() ->
+            validator.validate(facesContext, component, null));
+    }
+
+    @Test
+    void testEmptyValue_noException() {
+        assertDoesNotThrow(() ->
+            validator.validate(facesContext, component, ""));
+    }
+
+    @Test
+    void testInvalidIBAN_lowercase() {
+        ValidatorException ex = assertThrows(ValidatorException.class, () ->
+                validator.validate(facesContext, component, "de91100000000123456789"));
+        assertNotNull(ex.getFacesMessage());
+        assertEquals("IBAN has invalid country code", ex.getFacesMessage().getSummary());
+    }
+
+    @Test
+    void testInvalidIBAN_wrongCheckDigit() {
+        ValidatorException ex = assertThrows(ValidatorException.class, () ->
+            validator.validate(facesContext, component, "DE00100000000123456789"));
+        assertNotNull(ex.getFacesMessage());
+        assertEquals("IBAN violates ISO 7064 Mod 97-10 checksum check", ex.getFacesMessage().getSummary());
+    }
+
+    @Test
+    void testInvalidIBAN_unknownCountry() {
+        ValidatorException ex = assertThrows(ValidatorException.class, () ->
+            validator.validate(facesContext, component, "XX91100000000123456789"));
+        assertNotNull(ex.getFacesMessage());
+        assertEquals("IBAN has unsupported country code", ex.getFacesMessage().getSummary());
+    }
+
+    @Test
+    void testInvalidIBAN_tooShort() {
+        ValidatorException ex = assertThrows(ValidatorException.class, () ->
+            validator.validate(facesContext, component, "DE91"));
+        assertNotNull(ex.getFacesMessage());
+        assertEquals("IBAN has incorrect length", ex.getFacesMessage().getSummary());
+    }
+
+    @Test
+    void testInvalidIBAN_garbage() {
+        ValidatorException ex = assertThrows(ValidatorException.class, () ->
+            validator.validate(facesContext, component, "NOT-AN-IBAN"));
+        assertNotNull(ex.getFacesMessage());
+        assertEquals("IBAN has invalid check digits", ex.getFacesMessage().getSummary());
+    }
+
+}


### PR DESCRIPTION
Hi again,

this pr replaces the `iban4j` dependency with  the more modern and powerful [`iban-commons`](https://github.com/SpeedBankingDe/iban-commons) (`de.speedbanking`) in `pom.xml`, `IBANValidator`, and `BICValidator`.

The new library is zero-dependency, ~6x faster than iban4j, and uses ~12x less memory per operation. Both validators now delegate to a single `Iban.of()` / `Bic.of()` call.
The separate `iban4j` exception types (`IbanFormatException`, `InvalidCheckDigitException`, `UnsupportedCountryException`, etc.) collapse into one each (`InvalidIbanException` / `InvalidBicException`).
Also added Javadoc and JUnit 5 tests to both validators.