### PR TITLE
chore(deps): bump iban-commons 1.8.3 → 1.8.7

### DIFF
--- a/imixs-office-workflow-util/pom.xml
+++ b/imixs-office-workflow-util/pom.xml
@@ -63,11 +63,11 @@
 			<artifactId>imixs-adapters-poi</artifactId>
 		</dependency>
 
-		<!-- tiny java lib for IBAN/BIC validation -->
+		<!-- java lib for IBAN/BIC validation -->
 		<dependency>
 			<groupId>de.speedbanking</groupId>
 			<artifactId>iban-commons</artifactId>
-			<version>1.8.3</version>
+			<version>1.8.7</version>
 		</dependency>
 
 	</dependencies>

--- a/imixs-office-workflow-util/src/main/java/org/imixs/workflow/office/forms/BICValidator.java
+++ b/imixs-office-workflow-util/src/main/java/org/imixs/workflow/office/forms/BICValidator.java
@@ -28,7 +28,7 @@ public class BICValidator implements Validator<String> {
         if (value != null && !value.isEmpty()) {
 
             try {
-                Bic.of(value.replaceAll("\\s+", ""));
+                Bic.validate(value.replaceAll("\\s+", ""));
             } catch (InvalidBicException ex) {
                 throw new ValidatorException(new FacesMessage(ex.getMessage()), ex);
             }

--- a/imixs-office-workflow-util/src/main/java/org/imixs/workflow/office/forms/IBANValidator.java
+++ b/imixs-office-workflow-util/src/main/java/org/imixs/workflow/office/forms/IBANValidator.java
@@ -28,7 +28,7 @@ public class IBANValidator implements Validator<String> {
         if (value != null && !value.isEmpty()) {
 
             try {
-                Iban.of(value);
+                Iban.validate(value);
             } catch (InvalidIbanException ex) {
                 throw new ValidatorException(new FacesMessage(ex.getMessage()), ex);
             }


### PR DESCRIPTION
Bumps `iban-commons` from 1.8.3 to 1.8.7 and switches both JSF validators to the new allocation-free API.
`Iban.validate()` and `Bic.validate()` carry the same exception contract as `of()` - invalid input throws `InvalidIbanException`/`InvalidBicException` with full error detail - but skip constructing the domain object, which is unnecessary in a validation-only context.